### PR TITLE
Filter services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV STATS_PORT=1936 \
     FRONTEND_PORT=80 \
     COOKIES_ENABLED=false \
     BACKEND_NAME=http-backend \
-    BALANCE=roundrobin
+    BALANCE=roundrobin \
+    SERVICE_NAMES= 
 
 CMD ["start"]

--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,28 @@ and then run
 
     $ docker build -t your-image-name:your-image-tag path/to/Dockerfile
 
+### Run with Docker Compose and multiple web apps
+
+If you have multiple apps running on port 80 HAProxy will by default proxy them all. If you want
+to restrict it to just one app then specify the `SERVICE_NAMES` environment variable.
+
+    haproxy:
+      image: eeacms/haproxy
+      links:
+      - webapp
+      ports:
+      - "80:80"
+      - "1936:1936"
+      environment:
+      - SERVICE_NAMES=webapp
+
+    webapp:
+      image: razvan3895/nodeserver
+
+    secondwebapp:
+      image: razvan3895/nodeserver
+
+Note that haproxy will not serve requests from `secondwebapp` because of the `SERVICE_NAMES` variable.
 
 ### Upgrade
 

--- a/Readme.md
+++ b/Readme.md
@@ -127,6 +127,7 @@ preferably by supplying an `.env` file in the appropriate tag.
   * `BACKEND_NAME` The label of the backend - default `http-backend`
   * `BACKENDS` The list of `server_ip:server_listening_port` to be load-balanced by HAProxy, separated by space - by default it is not set
   * `BALANCE` The algorithm used for load-balancing - default `roundrobin`
+  * `SERVICE_NAMES` An optional prefix for services to be included when discovering services. - by default it is not set
 
 
 ## Copyright and license

--- a/configure.py
+++ b/configure.py
@@ -7,6 +7,7 @@ if sys.argv[1] == "update":
     configuration = open("/etc/haproxy/haproxy.cfg", "a")
     index = 1
     backend_conf = ""
+    service_names = os.environ['SERVICE_NAMES'].split(';')
 
     try:
         hosts = open("/etc/hosts")
@@ -23,8 +24,11 @@ if sys.argv[1] == "update":
     for host in hosts:
         if "0.0.0.0" in host or "127.0.0.1" in host or localhost in host or "::" in host:
             continue
-        host_ip = host.split()[0]
-        if host_ip in existing_hosts:
+        part = host.split()
+        if len(part) < 2:
+            continue
+        (host_ip, host_name) = part[0:2]
+        if host_ip in existing_hosts or not any(host_name.startswith(name) for name in service_names):
             continue
         existing_hosts.append(host_ip)
         backend_conf += """        server http-server%d %s:80 %s check\n""" % (index, host_ip, cookies)
@@ -66,6 +70,8 @@ with open("/etc/haproxy/haproxy.cfg", "a") as configuration:
     else:
         cookies = ""
 
+    service_names = os.environ['SERVICE_NAMES'].split(';')
+
     if sys.argv[1] == "hosts":
         try:
             hosts = open("/etc/hosts")
@@ -79,8 +85,11 @@ with open("/etc/haproxy/haproxy.cfg", "a") as configuration:
         for host in hosts:
             if "0.0.0.0" in host or "127.0.0.1" in host or localhost in host or "::" in host:
                 continue
-            host_ip = host.split()[0]
-            if host_ip in existing_hosts:
+            part = host.split()
+            if len(part) < 2:
+                continue
+            (host_ip, host_name) = part[0:2]
+            if host_ip in existing_hosts or not any(host_name.startswith(name) for name in service_names):
                 continue
             existing_hosts.append(host_ip)
             backend_conf += """        server http-server%d %s:80 %s check\n""" % (index, host_ip, cookies)


### PR DESCRIPTION
This PR adds the ability to filter services with an optional `SERVICE_NAMES` environment variable, and documentation for its use.

Recently I tried to use this docker image in a docker-compose service that had multiple roles with services running on port 80. To my dismay the load balancer balanced not only the explicitly linked roles, but every role in the service. This is due to a Docker discovery feature that adds every service to the hosts file.

I figured seeing as you were nice enough to provide this image I'd send back this change that makes it possible to filter the list of services that get load balanced with a csv of strings to match against. See the added documentation on the `Readme.md` for info. Feel free to delete this PR if not interested -- I just didn't see any contribution guidelines :)