### PR TITLE
Proxy protocol

### DIFF
--- a/haproxy/Readme.md
+++ b/haproxy/Readme.md
@@ -19,7 +19,7 @@ instead of **80**. Please update your deployment accordingly.
 ### Changes
 
  - [CHANGELOG.md](https://github.com/eea/eea.docker.haproxy/blob/master/CHANGELOG.md)
- 
+
 ### Base docker image
 
  - [hub.docker.com](https://registry.hub.docker.com/u/eeacms/haproxy)
@@ -32,7 +32,7 @@ instead of **80**. Please update your deployment accordingly.
 
 ### Installation
 
-1. Install [Docker](https://www.docker.com/) **Please note**: version must not be 1.8.x due to docker issue [#16619](https://github.com/docker/docker/issues/16619) 
+1. Install [Docker](https://www.docker.com/) **Please note**: version must not be 1.8.x due to docker issue [#16619](https://github.com/docker/docker/issues/16619)
 2. Install [Docker Compose](https://docs.docker.com/compose/install/).
 
 ## Usage
@@ -159,6 +159,7 @@ either when running the container or in a `docker-compose.yml` file.
   * `STATS_AUTH` The authentication details (written as `user:password` for the statistics page - default `admin:admin`
   * `FRONTEND_NAME` The label of the frontend - default `http-frontend`
   * `FRONTEND_PORT` The port to bind the frontend to - default `5000`
+  * `PROXY_PROTOCOL_ENABLED` The option to enable or disable accepting proxy protocol (`true` stands for enabled, `false` or anything else for disabled) - default `false`
   * `COOKIES_ENABLED` The option to enable or disable cookie-based sessions (`true` stands for enabled, `false` or anything else for disabled) - default `false`
   * `BACKEND_NAME` The label of the backend - default `http-backend`
   * `BACKENDS` The list of `server_ip:server_listening_port` to be load-balanced by HAProxy, separated by space - by default it is not set
@@ -166,7 +167,7 @@ either when running the container or in a `docker-compose.yml` file.
   * `BALANCE` The algorithm used for load-balancing - default `roundrobin`
   * `SERVICE_NAMES` An optional prefix for services to be included when discovering services separated by space. - by default it is not set
   * `LOGGING` Override logging ip address:port - default is udp `127.0.0.1:514` inside container
-  
+
 
 ## Logging
 

--- a/haproxy/src/configure.py
+++ b/haproxy/src/configure.py
@@ -8,6 +8,7 @@ BACKEND_NAME = os.environ.get('BACKEND_NAME', 'http-backend')
 BALANCE = os.environ.get('BALANCE', 'roundrobin')
 SERVICE_NAMES = os.environ.get('SERVICE_NAMES', '')
 COOKIES_ENABLED = (os.environ.get('COOKIES_ENABLED', 'false').lower() == "true")
+PROXY_PROTOCOL_ENABLED = (os.environ.get('PROXY_PROTOCOL_ENABLED', 'false').lower() == "true")
 STATS_PORT = os.environ.get('STATS_PORT', '1936')
 STATS_AUTH = os.environ.get('STATS_AUTH', 'admin:admin')
 BACKENDS = os.environ.get('BACKENDS', '').split(' ')
@@ -25,7 +26,7 @@ listen_conf = """
 
 frontend_conf = """
   frontend %(name)s
-    bind *:%(port)s
+    bind *:%(port)s %(accept_proxy)s
     mode http
     default_backend %(backend)s
 """
@@ -59,6 +60,11 @@ with open("/etc/haproxy/haproxy.cfg", "w") as configuration:
         cookies = "cookie value"
     else:
         cookies = ""
+
+    if PROXY_PROTOCOL_ENABLED:
+        accept_proxy = "accept-proxy"
+    else:
+        accept_proxy = ""
 
     if ';' in SERVICE_NAMES:
         #BBB
@@ -120,6 +126,9 @@ with open("/etc/haproxy/haproxy.cfg", "w") as configuration:
 
     configuration.write(listen_conf % dict(port=STATS_PORT, auth=STATS_AUTH))
     configuration.write(frontend_conf % dict(
-        name=FRONTEND_NAME, port=FRONTEND_PORT, backend=BACKEND_NAME
+        name=FRONTEND_NAME,
+        port=FRONTEND_PORT,
+        backend=BACKEND_NAME,
+        accept_proxy=accept_proxy
     ))
     configuration.write(backend_conf)


### PR DESCRIPTION
Add support for the [accept-proxy](http://cbonte.github.io/haproxy-dconv/configuration-1.7.html#5.1-accept-proxy) bind option which is useful when configuring websockets behind an ELB.

See also:

https://medium.com/@Philmod/load-balancing-websockets-on-ec2-1da94584a5e9#.5pym8ce8w