### PR TITLE
[entrypoint] Fix backend override when we specify BACKENDS

### DIFF
--- a/haproxy/docker-entrypoint.sh
+++ b/haproxy/docker-entrypoint.sh
@@ -20,9 +20,8 @@ if ! test -e /etc/haproxy/haproxy.cfg; then
         # Find backend within /etc/hosts
         touch /etc/haproxy/hosts.backends
         python3 /configure.py hosts
+        echo "*/${DNS_TTL:-1} * * * * /track_hosts  | logger " > /var/crontab.txt
       fi
-    
-      echo "*/${DNS_TTL:-1} * * * * /track_hosts  | logger " > /var/crontab.txt
     
     fi
     


### PR DESCRIPTION
Only enable /track_hosts cron when BACKENDS env var is not present.
Otherwise /track_hosts will overwrite and mess up our backends