### PR TITLE
Max connections,  stats refresh and weighted backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2022-08-25
+- Add  `MAXCONN` environment variable to limit max connection among backends  (default to `0` - unlimited) [sauzher]
+- Add `STATS_REFRESH` environment variable to enable auto refresh. (default to `0` - no refresh) [sauzher]
+- Add optional weight parameter for remote backends `host:port:weight` (default to `1` - all same weight) [sauzher]
+
 ## 2021-06-14 (1.8-1.7)
 
 - Upgrade HAProxy to 1.8.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 # Changelog
 
+## 2021-06-14 (1.8-1.7)
+
+- Upgrade HAProxy to 1.8.30
+- Add `COOKIES_NAME` parameter to configure cookie name
+- Add `HTTPCHK_HOST` parameter to allow health check to include host HTTP Header - refs #20
+
 ## 2021-03-23 (1.8-1.6)
 
 - Upgrade HAProxy to 1.8.29
 - Fixed code to work with new HAProxy configuration location - /usr/local/etc/haproxy/haproxy.cfg
-- Fix backend port when DNS_ENABLED - refs #24
-
-## 2020-03-26 (1.8-1.5)
-
-- Add HTTPCHK_HOST variable to allow health check to include "Host: xyz.com" HTTP Header. Defaults to "localhost"
+- Fix backend port when `DNS_ENABLED` - refs #24
 
 ## 2019-11-28 (1.8-1.5)
 
-- Add COOKIES_PARAMS variable to give the possibility to add expiration time to cookies
+- Add `COOKIES_PARAMS` variable to give the possibility to add expiration time to cookies
 
 ## 2019-11-22 (1.8-1.4)
 

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.8.29
+FROM haproxy:1.8.30
 LABEL maintainer="EEA: IDM2 A-Team <eea-edw-a-team-alerts@googlegroups.com>"
 
 RUN apt-get update \

--- a/haproxy/Readme.md
+++ b/haproxy/Readme.md
@@ -134,6 +134,7 @@ either when running the container or in a `docker-compose.yml` file.
   * `FRONTEND_MODE` Frontend mode - default `http` or `BACKENDS_MODE` if declared
   * `PROXY_PROTOCOL_ENABLED` The option to enable or disable accepting proxy protocol (`true` stands for enabled, `false` or anything else for disabled) - default `false`
   * `COOKIES_ENABLED` The option to enable or disable cookie-based sessions (`true` stands for enabled, `false` or anything else for disabled) - default `false`
+  * `COOKIES_NAME` Will be added on cookie declaration - default `SRV_ID`
   * `COOKIES_PARAMS` Will be added on cookie declaration - example `indirect nocache maxidle 30m maxlife 8h` or `maxlife 24h` - documentation https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-cookie
   * `BACKEND_NAME` The label of the backend - default `http-backend`
   * `BACKENDS` The list of `server_ip:server_listening_port` to be load-balanced by HAProxy, separated by space - by default it is not set

--- a/haproxy/Readme.md
+++ b/haproxy/Readme.md
@@ -152,6 +152,7 @@ either when running the container or in a `docker-compose.yml` file.
   * `HTTPCHK` The HTTP method and uri used to check on the servers health - default `HEAD /`
   * `HTTPCHK_HOST` Host Header override on http Health Check - default `localhost`
   * `INTER` parameter sets the interval between two consecutive health checks. If not specified, the default value is `2s`
+  * `MAXCONN` parameter sets the maximum number of connection that each backend will accept and, by default, is set to `0` (no limit)
   * `FAST_INTER` parameter sets the interval between two consecutive health checks when the server is any of the transition state (read above): UP - transitionally DOWN or DOWN - transitionally UP. If not set, then `INTER` is used.
   * `DOWN_INTER` parameter sets the interval between two consecutive health checks when the server is in the DOWN state. If not set, then `INTER` is used.
   * `RISE` number of consecutive valid health checks before considering the server as UP. Default value is `2`

--- a/haproxy/Readme.md
+++ b/haproxy/Readme.md
@@ -84,12 +84,14 @@ minimum possible `DNS_TTL`.
 ### Run with backends specified as environment variable
 
     $ docker run --env BACKENDS="192.168.1.5:80 192.168.1.6:80" eeacms/haproxy
+or
+    $ docker run --env BACKENDS="192.168.1.5:80:4 192.168.1.6:80:1" eeacms/haproxy
 
 Using the `BACKENDS` variable is a way to quick-start the container.
-The servers are written as `server_ip:server_listening_port`,
+The servers are written as `server_ip:server_listening_port:weight`,
 separated by spaces (and enclosed in quotes, to avoid issues).
 The contents of the variable are evaluated in a python script that writes
-the HAProxy configuration file automatically.
+the HAProxy configuration file automatically. `weight` is optional and defaulted to `1`
 
 If there are multiple DNS records for one or more of your `BACKENDS` (e.g. when deployed using rancher-compose),
 you can use `DNS_ENABLED` environment variable. This way, haproxy will load-balance
@@ -140,7 +142,7 @@ either when running the container or in a `docker-compose.yml` file.
   * `COOKIES_NAME` Will be added on cookie declaration - default `SRV_ID`
   * `COOKIES_PARAMS` Will be added on cookie declaration - example `indirect nocache maxidle 30m maxlife 8h` or `maxlife 24h` - documentation https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-cookie
   * `BACKEND_NAME` The label of the backend - default `http-backend`
-  * `BACKENDS` The list of `server_ip:server_listening_port` to be load-balanced by HAProxy, separated by space - by default it is not set
+  * `BACKENDS` The list of `server_ip:server_listening_port:weight` to be load-balanced by HAProxy, separated by space - by default it is not set - by default weight is 1
   * `BACKENDS_PORT` Port to use when auto-discovering backends, or when `BACKENDS` are specified without port - by default `80`
   * `BACKENDS_MODE` Backends mode - default `http` or `FRONTEND_MODE` if declared
   * `BALANCE` The algorithm used for load-balancing - default `roundrobin`
@@ -160,7 +162,6 @@ either when running the container or in a `docker-compose.yml` file.
   * `DOWN_INTER` parameter sets the interval between two consecutive health checks when the server is in the DOWN state. If not set, then `INTER` is used.
   * `RISE` number of consecutive valid health checks before considering the server as UP. Default value is `2`
   * `FALL` number of consecutive invalid health checks before considering the server as DOWN. Default value is `3`
-
 
 ## Logging
 

--- a/haproxy/docker-entrypoint.sh
+++ b/haproxy/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 
 # haproxy not directly configured within /usr/local/etc/haproxy/haproxy.cfg
 if ! test -e /usr/local/etc/haproxy/haproxy.cfg; then
-    if [ ! -z "$DNS_ENABLED" ]; then
+    if [ -n "$DNS_ENABLED" ]; then
       # Backends are resolved using internal or external DNS service
       touch /etc/haproxy/dns.backends
       python3 /configure.py dns
@@ -12,7 +12,7 @@ if ! test -e /usr/local/etc/haproxy/haproxy.cfg; then
     
     else
     
-      if [ ! -z "$BACKENDS" ]; then
+      if [ -n "$BACKENDS" ]; then
         # Backend provided via $BACKENDS env
         python3 /configure.py env
       else
@@ -30,32 +30,33 @@ if ! test -e /usr/local/etc/haproxy/haproxy.cfg; then
     
     #Add env variables for haproxy
     echo "export PATH=$PATH"':$PATH' >> /etc/environment
-    if [ ! -z "$BACKENDS" ]; then echo "export BACKENDS=\"$BACKENDS\""  >> /etc/environment; fi
-    if [ ! -z "$BACKENDS_PORT" ]; then echo "export BACKENDS_PORT=\"$BACKENDS_PORT\""  >> /etc/environment; fi
-    if [ ! -z "$BACKENDS_MODE" ]; then echo "export BACKENDS_MODE=\"$BACKENDS_MODE\""  >> /etc/environment; fi
-    if [ ! -z "$BACKEND_NAME" ]; then echo "export BACKEND_NAME=\"$BACKEND_NAME\""  >> /etc/environment; fi
-    if [ ! -z "$BALANCE" ]; then echo "export BALANCE=\"$BALANCE\""  >> /etc/environment; fi
-    if [ ! -z "$COOKIES_ENABLED" ]; then echo "export COOKIES_ENABLED=\"$COOKIES_ENABLED\""  >> /etc/environment; fi
-    if [ ! -z "$COOKIES_PARAMS" ]; then echo "export COOKIES_PARAMS=\"$COOKIES_PARAMS\""  >> /etc/environment; fi
-    if [ ! -z "$DOWN_INTER" ]; then echo "export DOWN_INTER=\"$DOWN_INTER\""  >> /etc/environment; fi
-    if [ ! -z "$FALL" ]; then echo "export FALL=\"$FALL\""  >> /etc/environment; fi
-    if [ ! -z "$FAST_INTER" ]; then echo "export FAST_INTER=\"$FAST_INTER\""  >> /etc/environment; fi
-    if [ ! -z "$FRONTEND_NAME" ]; then echo "export FRONTEND_NAME=\"$FRONTEND_NAME\""  >> /etc/environment; fi
-    if [ ! -z "$FRONTEND_PORT" ]; then echo "export FRONTEND_PORT=\"$FRONTEND_PORT\""  >> /etc/environment; fi
-    if [ ! -z "$FRONTEND_MODE" ]; then echo "export FRONTEND_MODE=\"$FRONTEND_MODE\""  >> /etc/environment; fi
-    if [ ! -z "$HTTPCHK" ]; then echo "export HTTPCHK=\"$HTTPCHK\""  >> /etc/environment; fi
-    if [ ! -z "$HTTPCHK_HOST" ]; then echo "export HTTPCHK_HOST=\"$HTTPCHK_HOST\""  >> /etc/environment; fi
-    if [ ! -z "$INTER" ]; then echo "export INTER=\"$INTER\""  >> /etc/environment; fi
-    if [ ! -z "$LOGGING" ]; then echo "export LOGGING=\"$LOGGING\""  >> /etc/environment; fi
-    if [ ! -z "$LOG_LEVEL" ]; then echo "export LOG_LEVEL=\"$LOG_LEVEL\""  >> /etc/environment; fi
-    if [ ! -z "$PROXY_PROTOCOL_ENABLED" ]; then echo "export PROXY_PROTOCOL_ENABLED=\"$PROXY_PROTOCOL_ENABLED\""  >> /etc/environment; fi
-    if [ ! -z "$RISE" ]; then echo "export RISE=\"$RISE\""  >> /etc/environment; fi
-    if [ ! -z "$SERVICE_NAMES" ]; then echo "export SERVICE_NAMES=\"$SERVICE_NAMES\""  >> /etc/environment; fi
-    if [ ! -z "$STATS_AUTH" ]; then echo "export STATS_AUTH=\"$STATS_AUTH\""  >> /etc/environment; fi
-    if [ ! -z "$STATS_PORT" ]; then echo "export STATS_PORT=\"$STATS_PORT\""  >> /etc/environment; fi
-    if [ ! -z "$TIMEOUT_CLIENT" ]; then echo "export TIMEOUT_CLIENT=\"$TIMEOUT_CLIENT\""  >> /etc/environment; fi
-    if [ ! -z "$TIMEOUT_CONNECT" ]; then echo "export TIMEOUT_CONNECT=\"$TIMEOUT_CONNECT\""  >> /etc/environment; fi
-    if [ ! -z "$TIMEOUT_SERVER" ]; then echo "export TIMEOUT_SERVER=\"$TIMEOUT_SERVER\""  >> /etc/environment; fi
+    if [ -n "$BACKENDS" ]; then echo "export BACKENDS=\"$BACKENDS\""  >> /etc/environment; fi
+    if [ -n "$BACKENDS_PORT" ]; then echo "export BACKENDS_PORT=\"$BACKENDS_PORT\""  >> /etc/environment; fi
+    if [ -n "$BACKENDS_MODE" ]; then echo "export BACKENDS_MODE=\"$BACKENDS_MODE\""  >> /etc/environment; fi
+    if [ -n "$BACKEND_NAME" ]; then echo "export BACKEND_NAME=\"$BACKEND_NAME\""  >> /etc/environment; fi
+    if [ -n "$BALANCE" ]; then echo "export BALANCE=\"$BALANCE\""  >> /etc/environment; fi
+    if [ -n "$COOKIES_ENABLED" ]; then echo "export COOKIES_ENABLED=\"$COOKIES_ENABLED\""  >> /etc/environment; fi
+    if [ -n "$COOKIES_NAME" ]; then echo "export COOKIES_NAME=\"$COOKIES_NAME\""  >> /etc/environment; fi
+    if [ -n "$COOKIES_PARAMS" ]; then echo "export COOKIES_PARAMS=\"$COOKIES_PARAMS\""  >> /etc/environment; fi
+    if [ -n "$DOWN_INTER" ]; then echo "export DOWN_INTER=\"$DOWN_INTER\""  >> /etc/environment; fi
+    if [ -n "$FALL" ]; then echo "export FALL=\"$FALL\""  >> /etc/environment; fi
+    if [ -n "$FAST_INTER" ]; then echo "export FAST_INTER=\"$FAST_INTER\""  >> /etc/environment; fi
+    if [ -n "$FRONTEND_NAME" ]; then echo "export FRONTEND_NAME=\"$FRONTEND_NAME\""  >> /etc/environment; fi
+    if [ -n "$FRONTEND_PORT" ]; then echo "export FRONTEND_PORT=\"$FRONTEND_PORT\""  >> /etc/environment; fi
+    if [ -n "$FRONTEND_MODE" ]; then echo "export FRONTEND_MODE=\"$FRONTEND_MODE\""  >> /etc/environment; fi
+    if [ -n "$HTTPCHK" ]; then echo "export HTTPCHK=\"$HTTPCHK\""  >> /etc/environment; fi
+    if [ -n "$HTTPCHK_HOST" ]; then echo "export HTTPCHK_HOST=\"$HTTPCHK_HOST\""  >> /etc/environment; fi
+    if [ -n "$INTER" ]; then echo "export INTER=\"$INTER\""  >> /etc/environment; fi
+    if [ -n "$LOGGING" ]; then echo "export LOGGING=\"$LOGGING\""  >> /etc/environment; fi
+    if [ -n "$LOG_LEVEL" ]; then echo "export LOG_LEVEL=\"$LOG_LEVEL\""  >> /etc/environment; fi
+    if [ -n "$PROXY_PROTOCOL_ENABLED" ]; then echo "export PROXY_PROTOCOL_ENABLED=\"$PROXY_PROTOCOL_ENABLED\""  >> /etc/environment; fi
+    if [ -n "$RISE" ]; then echo "export RISE=\"$RISE\""  >> /etc/environment; fi
+    if [ -n "$SERVICE_NAMES" ]; then echo "export SERVICE_NAMES=\"$SERVICE_NAMES\""  >> /etc/environment; fi
+    if [ -n "$STATS_AUTH" ]; then echo "export STATS_AUTH=\"$STATS_AUTH\""  >> /etc/environment; fi
+    if [ -n "$STATS_PORT" ]; then echo "export STATS_PORT=\"$STATS_PORT\""  >> /etc/environment; fi
+    if [ -n "$TIMEOUT_CLIENT" ]; then echo "export TIMEOUT_CLIENT=\"$TIMEOUT_CLIENT\""  >> /etc/environment; fi
+    if [ -n "$TIMEOUT_CONNECT" ]; then echo "export TIMEOUT_CONNECT=\"$TIMEOUT_CONNECT\""  >> /etc/environment; fi
+    if [ -n "$TIMEOUT_SERVER" ]; then echo "export TIMEOUT_SERVER=\"$TIMEOUT_SERVER\""  >> /etc/environment; fi
 fi
 
 

--- a/haproxy/docker-entrypoint.sh
+++ b/haproxy/docker-entrypoint.sh
@@ -51,6 +51,7 @@ if ! test -e /usr/local/etc/haproxy/haproxy.cfg; then
     if [ -n "$LOG_LEVEL" ]; then echo "export LOG_LEVEL=\"$LOG_LEVEL\""  >> /etc/environment; fi
     if [ -n "$PROXY_PROTOCOL_ENABLED" ]; then echo "export PROXY_PROTOCOL_ENABLED=\"$PROXY_PROTOCOL_ENABLED\""  >> /etc/environment; fi
     if [ -n "$RISE" ]; then echo "export RISE=\"$RISE\""  >> /etc/environment; fi
+    if [ -n "$MAXCONN" ]; then echo "export MAXCONN=\"$MAXCONN\""  >> /etc/environment; fi
     if [ -n "$SERVICE_NAMES" ]; then echo "export SERVICE_NAMES=\"$SERVICE_NAMES\""  >> /etc/environment; fi
     if [ -n "$STATS_AUTH" ]; then echo "export STATS_AUTH=\"$STATS_AUTH\""  >> /etc/environment; fi
     if [ -n "$STATS_PORT" ]; then echo "export STATS_PORT=\"$STATS_PORT\""  >> /etc/environment; fi

--- a/haproxy/src/configure.py
+++ b/haproxy/src/configure.py
@@ -35,6 +35,7 @@ FAST_INTER = os.environ.get('FAST_INTER', INTER)
 DOWN_INTER = os.environ.get('DOWN_INTER', INTER)
 RISE = os.environ.get('RISE', '2')
 FALL = os.environ.get('FALL', '3')
+MAXCONN = os.environ.get('MAXCONN', '2')
 
 
 listen_conf = Template("""
@@ -62,7 +63,7 @@ if COOKIES_ENABLED:
   backend $backend
     mode $mode
     balance $balance
-    default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise
+    default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise maxconn $maxconn
     cookie $cookies_name insert $cookies_params
 """)
     cookies = "cookie \\\"@@value@@\\\""
@@ -74,7 +75,7 @@ else:
   backend $backend
     mode $mode
     balance $balance
-    default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise
+    default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise maxconn $maxconn
     cookie $cookies_name prefix $cookies_params
 """)
     cookies = ""
@@ -105,7 +106,8 @@ backend_conf = backend_conf.substitute(
     fall=FALL,
     rise=RISE,
     cookies_name=COOKIES_NAME,
-    cookies_params=COOKIES_PARAMS
+    cookies_params=COOKIES_PARAMS,
+    maxconn=MAXCONN
 )
 
 if BACKENDS_MODE == 'http':

--- a/haproxy/src/configure.py
+++ b/haproxy/src/configure.py
@@ -15,6 +15,7 @@ BACKEND_NAME = os.environ.get('BACKEND_NAME', 'http-backend')
 BALANCE = os.environ.get('BALANCE', 'roundrobin')
 SERVICE_NAMES = os.environ.get('SERVICE_NAMES', '')
 COOKIES_ENABLED = (os.environ.get('COOKIES_ENABLED', 'false').lower() == "true")
+COOKIES_NAME = os.environ.get('COOKIES_NAME','SRV_ID')
 COOKIES_PARAMS = os.environ.get('COOKIES_PARAMS','')
 PROXY_PROTOCOL_ENABLED = (os.environ.get('PROXY_PROTOCOL_ENABLED', 'false').lower() == "true")
 STATS_PORT = os.environ.get('STATS_PORT', '1936')
@@ -54,7 +55,7 @@ frontend_conf = Template("""
 
 if COOKIES_ENABLED:
     #if we choose to enable session stickiness
-    #then insert a cookie named SRV_ID to the request:
+    #then insert a cookie named $COOKIES_NAME(SRV_ID) to the request:
     #all responses from HAProxy to the client will contain a Set-Cookie:
     #header with a specific value for each backend server as its cookie value.
     backend_conf = Template("""
@@ -62,7 +63,7 @@ if COOKIES_ENABLED:
     mode $mode
     balance $balance
     default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise
-    cookie SRV_ID insert $cookies_params
+    cookie $cookies_name insert $cookies_params
 """)
     cookies = "cookie \\\"@@value@@\\\""
 else:
@@ -74,7 +75,7 @@ else:
     mode $mode
     balance $balance
     default-server inter $inter fastinter $fastinter downinter $downinter fall $fall rise $rise
-    cookie SRV_ID prefix $cookies_params
+    cookie $cookies_name prefix $cookies_params
 """)
     cookies = ""
 
@@ -103,6 +104,7 @@ backend_conf = backend_conf.substitute(
     downinter=DOWN_INTER,
     fall=FALL,
     rise=RISE,
+    cookies_name=COOKIES_NAME,
     cookies_params=COOKIES_PARAMS
 )
 

--- a/haproxy/src/configure.py
+++ b/haproxy/src/configure.py
@@ -90,7 +90,7 @@ backend_type_http = Template("""
 """)
 
 backend_conf_plus = Template("""
-    server $name-$index $host:$port $cookies check
+    server $name-$index $host:$port $cookies check weight $weight
 """)
 
 health_conf = """
@@ -146,6 +146,7 @@ if sys.argv[1] == "dns":
             index=ip.replace(".", "-"),
             host=ip,
             port=port,
+            weight=1,
             cookies=cookies.replace('@@value@@', ip))
 
 ################################################################################
@@ -157,11 +158,13 @@ elif sys.argv[1] == "env":
         server_port = backend_server.split(':')
         host = server_port[0]
         port = server_port[1] if len(server_port) > 1 else BACKENDS_PORT
+        weight = server_port[2] if len(server_port) > 2 else 1
         backend_conf += backend_conf_plus.substitute(
                 name=host.replace(".", "-"),
                 index=index,
                 host=host,
                 port=port,
+                weight=weight,
                 cookies=cookies.replace('@@value@@', host))
 
 ################################################################################
@@ -212,6 +215,7 @@ elif sys.argv[1] == "hosts":
                 index=index,
                 host=host_ip,
                 port=host_port,
+                weight=1,
                 cookies=cookies.replace('@@value@@', host_ip)
         )
         index += 1


### PR DESCRIPTION
Adds two enviroment parameters `MAX_CONN`, `STATS_REFRESH` and the possibility to add a `weight` to backends when specified as remote host in the `BACKENDS` variable.

 -e MAX_CONN="4" will caps 4 connection on each backend
 -e STATS_REFRESH="5s" will enable auto refresh of the stats page every 5 seconds
 -e BACKENDS "192.168.10.10:8080:4 192.168.20.10:8080:1" will apply a tuning to load balancer algorithm (4 times more hit on the first server)

`:weight` is optional anyway